### PR TITLE
Fix minor syntax error

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,4 +82,4 @@ end-to-end user flows.
 
 ## Contributing
 
-Help defend democracy and [contribute to the project](CONTRIBUTING).
+Help defend democracy and [contribute to the project](CONTRIBUTING.md).


### PR DESCRIPTION
In the contributing section of the root readme file, the link to CONTRIBUTING.md was broken.

Fix #9 

